### PR TITLE
Reverting async component scan logic; 

### DIFF
--- a/curacao-embedded/pom.xml
+++ b/curacao-embedded/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>curacao</groupId>
         <artifactId>curacao-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
     </parent>
 
     <properties>

--- a/curacao-examples/pom.xml
+++ b/curacao-examples/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>curacao</groupId>
         <artifactId>curacao-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
     </parent>
 
     <properties>

--- a/curacao-gson/pom.xml
+++ b/curacao-gson/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>curacao</groupId>
         <artifactId>curacao-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
     </parent>
 
     <dependencies>

--- a/curacao-jackson/pom.xml
+++ b/curacao-jackson/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>curacao</groupId>
         <artifactId>curacao-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
     </parent>
 
     <dependencies>

--- a/curacao-junit4runner/pom.xml
+++ b/curacao-junit4runner/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>curacao</groupId>
         <artifactId>curacao-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
     </parent>
 
     <properties>

--- a/curacao/pom.xml
+++ b/curacao/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>curacao</groupId>
         <artifactId>curacao-parent</artifactId>
-        <version>4.3.0</version>
+        <version>4.3.1</version>
     </parent>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>curacao</groupId>
     <artifactId>curacao-parent</artifactId>
-    <version>4.3.0</version>
+    <version>4.3.1</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -20,7 +20,7 @@
 
         <kolich-common.version>0.5</kolich-common.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <reflections.version>0.9.10</reflections.version>
+        <reflections.version>0.9.11</reflections.version>
 
         <guava.version>22.0</guava.version>
         <gson.version>2.8.1</gson.version>
@@ -88,36 +88,36 @@
             <dependency>
                 <groupId>curacao</groupId>
                 <artifactId>curacao</artifactId>
-                <version>4.3.0</version>
+                <version>4.3.1</version>
             </dependency>
 
             <dependency>
                 <groupId>curacao</groupId>
                 <artifactId>curacao-gson</artifactId>
-                <version>4.3.0</version>
+                <version>4.3.1</version>
             </dependency>
             <dependency>
                 <groupId>curacao</groupId>
                 <artifactId>curacao-jackson</artifactId>
-                <version>4.3.0</version>
+                <version>4.3.1</version>
             </dependency>
 
             <dependency>
                 <groupId>curacao</groupId>
                 <artifactId>curacao-examples</artifactId>
-                <version>4.3.0</version>
+                <version>4.3.1</version>
             </dependency>
 
             <dependency>
                 <groupId>curacao</groupId>
                 <artifactId>curacao-embedded</artifactId>
-                <version>4.3.0</version>
+                <version>4.3.1</version>
             </dependency>
 
             <dependency>
                 <groupId>curacao</groupId>
                 <artifactId>curacao-junit4runner</artifactId>
-                <version>4.3.0</version>
+                <version>4.3.1</version>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
Reverting async component scan logic in release `4.3.0`.

Bit by nasty `org.reflections` bug:
https://github.com/ronmamo/reflections/issues/81

Bumping to version `4.3.1`.